### PR TITLE
fix: common issue with vineyard & crafting

### DIFF
--- a/bridge/frameworks/qb-core/server.lua
+++ b/bridge/frameworks/qb-core/server.lua
@@ -87,7 +87,7 @@ end
 function stevo_lib.HasItem(source, _item)
     local player = QBCore.Functions.GetPlayer(source)
     local item = player.Functions.GetItemByName(_item)
-    return item and (item.count or item.amount or 0)
+    return item and (item.count or item.amount) or 0
 end
 
 function stevo_lib.GetInventory(source)

--- a/bridge/frameworks/qbx_core/server.lua
+++ b/bridge/frameworks/qbx_core/server.lua
@@ -84,7 +84,7 @@ end
 function stevo_lib.HasItem(source, _item)
     local player = qbx_core:GetPlayer(source)
     local item = player.Functions.GetItemByName(_item)
-    return item and (item.count or item.amount or 0)
+    return item and (item.count or item.amount) or 0
 end
 
 function stevo_lib.GetInventory(source)

--- a/bridge/keys/qb-vehiclekeys/client.lua
+++ b/bridge/keys/qb-vehiclekeys/client.lua
@@ -1,6 +1,6 @@
 return {
 
   HasKeys = function(vehicle)
-    return exports.qbx_vehiclekeys:HasKeys(vehicle)
+    return exports.qb_vehiclekeys:HasKeys(vehicle)
   end
 }


### PR DESCRIPTION
fixed the common `attempt to perform arithmetic on a nil value (local 'amount')` issue for qb & qbox frameworks, fixed typo in qb-vehiclekeys

solves [issue #2](https://github.com/stevoscriptsteam/stevo_advancedvineyard/pull/2) and various issues reported by users in the discord