### PR TITLE
experimental ox_core support + various refactors 

### DIFF
--- a/bridge/frameworks/es_extended/client.lua
+++ b/bridge/frameworks/es_extended/client.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable: duplicate-set-field
 local ESX = exports.es_extended:getSharedObject()
 local PlayerData = ESX.GetPlayerData()
 local isDead
@@ -17,7 +18,7 @@ function stevo_lib.GetPlayerGroupInfo()
         grade = PlayerData.job.grade,
         label = PlayerData.job.label
     }
-    
+
     return jobInfo
 end
 
@@ -29,18 +30,17 @@ function stevo_lib.IsDead()
     return isDead
 end
 
-function stevo_lib.SetOutfit(outfit) 
-    if outfit then 
+function stevo_lib.SetOutfit(outfit)
+    if outfit then
         ESX.TriggerServerCallback('esx_skin:getPlayerSkin', function(skin, jobSkin)
             TriggerEvent('skinchanger:loadClothes', skin, outfit)
         end)
-    else 
+    else
         ESX.TriggerServerCallback('esx_skin:getPlayerSkin', function(skin, jobSkin)
             TriggerEvent('skinchanger:loadSkin', skin)
         end)
-    end 
+    end
 end
-
 
 AddEventHandler('esx:onPlayerSpawn', function(noAnim)
     isDead = nil
@@ -54,7 +54,7 @@ AddEventHandler('esx:onPlayerDeath', function(data)
     isDead = true
     TriggerEvent('stevo_lib:playerDied')
 end)
-		
+
 RegisterNetEvent('esx:playerLoaded', function()
     PlayerData = ESX.GetPlayerData()
     TriggerEvent('stevo_lib:playerLoaded')

--- a/bridge/frameworks/es_extended/server.lua
+++ b/bridge/frameworks/es_extended/server.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable: duplicate-set-field
 local ESX = exports.es_extended:getSharedObject()
 local ox_inventory = GetResourceState('ox_inventory') == 'started' and true or false
 
@@ -12,7 +13,7 @@ function stevo_lib.GetName(source)
     return player.getName()
 end
 
-function stevo_lib. GetJobCount(source, job)
+function stevo_lib.GetJobCount(source, job)
     return ESX.GetExtendedPlayers('job', job)
 end
 
@@ -35,7 +36,7 @@ function stevo_lib.GetPlayerJobInfo(source)
 end
 
 function stevo_lib.GetPlayerGangInfo(source)
-    return false    
+    return false
 end
 
 function stevo_lib.GetPlayers()
@@ -82,7 +83,7 @@ function stevo_lib.GetInventory(source)
     local player = ESX.GetPlayerFromId(source)
     local items = {}
     local data = ox_inventory and exports.ox_inventory:GetInventoryItems(source) or player.getInventory()
-    for i=1, #data do 
+    for i = 1, #data do
         local item = data[i]
         items[#items + 1] = {
             name = item.name,
@@ -105,4 +106,3 @@ end
 function stevo_lib.RegisterUsableItem(item, cb)
     ESX.RegisterUsableItem(item, cb)
 end
-

--- a/bridge/frameworks/ox_core/client.lua
+++ b/bridge/frameworks/ox_core/client.lua
@@ -1,0 +1,53 @@
+local Ox = require '@ox_core.lib.init'
+local player = Ox.GetPlayer()
+local isDead
+
+function stevo_lib.bridgeNotify(msg, type, duration)
+    -- ox_lib is a dependency of ox_core, `lib` will always be available
+    lib.notify({
+        description = msg,
+        type = type,
+        duration = duration
+    })
+end
+
+function stevo_lib.GetPlayerGroups()
+    return player.get('activeGroup'), false
+end
+
+function stevo_lib.GetPlayerGroupInfo()
+    local activeGroup = player.get('activeGroup')
+    local jobInfo = {
+        name = activeGroup,
+        grade = player.getGroup(activeGroup),
+        label = Ox.GetGroup(activeGroup).label
+    }
+
+    return jobInfo
+end
+
+function stevo_lib.GetSex()
+    -- ! ox_core has non_binary as a gender. for backwards compatibility non binary will return female
+    return player.get('gender') == 'male' and 1 or 2
+end
+
+function stevo_lib.IsDead()
+    return isDead
+end
+
+---@deprecated ox_core does not have built in support for outfits
+function stevo_lib.SetOutfit() end
+
+AddEventHandler('ox:playerRevived', function()
+    isDead = nil
+end)
+
+AddEventHandler('ox:playerDeath', function()
+    isDead = true
+    TriggerEvent('stevo_lib:playerDied')
+end)
+
+AddEventHandler('ox:playerLoaded', function()
+    player = Ox.GetPlayer()
+    TriggerEvent('stevo_lib:playerLoaded')
+end)

--- a/bridge/frameworks/ox_core/client.lua
+++ b/bridge/frameworks/ox_core/client.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable: duplicate-set-field
 local Ox = require '@ox_core.lib.init'
 local player = Ox.GetPlayer()
 local isDead

--- a/bridge/frameworks/ox_core/server.lua
+++ b/bridge/frameworks/ox_core/server.lua
@@ -1,0 +1,121 @@
+local Ox = require '@ox_core.lib.init'
+local ox_inventory = GetResourceState('ox_inventory') == 'started' and true or false
+
+
+function stevo_lib.GetIdentifier(source)
+    local player = Ox.GetPlayer(source)
+    return player.getIdentifier()
+end
+
+function stevo_lib.GetName(source)
+    local player = Ox.GetPlayer(source)
+    return player.get('firstName') .. ' ' .. player.get('lastName')
+end
+
+function stevo_lib.GetJobCount(source, job)
+    return GlobalState[job .. ':activeCount']
+end
+
+function stevo_lib.GetPlayerGroups(source)
+    local player = Ox.GetPlayer(source)
+    local job = player.get('activeGroup')
+    return job, false
+end
+
+function stevo_lib.GetPlayerJobInfo(source)
+    local player = Ox.GetPlayer(source)
+    local activeGroup = player.get('activeGroup')
+    local groupInfo = Ox.GetGroup(activeGroup)
+    local grade = player.getGroup(activeGroup)
+
+    local jobInfo = {
+        name = groupInfo.name,
+        label = groupInfo.label,
+        grade = grade,
+        gradeName = groupInfo.grades[grade],
+    }
+    return jobInfo
+end
+
+function stevo_lib.GetPlayerGangInfo(source) end -- * Not supported in ox_core natively - would require gangs to be set up with a specific type in DB
+
+function stevo_lib.GetPlayers()
+    local players = Ox.GetPlayers()
+    local formattedPlayers = {}
+    for _, v in pairs(players) do
+        local player = {
+            job = v.get('activeGroup'),
+            gang = false,
+            source = v.source
+        }
+        table.insert(formattedPlayers, player)
+    end
+    return formattedPlayers
+end
+
+function stevo_lib.GetDob(source)
+    local player = Ox.GetPlayer(source)
+    return player.get('dateOfBirth')
+end
+
+function stevo_lib.GetSex(source)
+    local player = ESX.GetPlayerFromId(source)
+    -- ! ox_core has non_binary as a gender. for backwards compatibility non binary will return female
+    return player.get('gender') == 'male' and 1 or 2
+end
+
+---@param source number
+---@param item string
+---@param count number
+function stevo_lib.RemoveItem(source, item, count)
+    if not ox_inventory then return false end
+    return exports.ox_inventory:RemoveItem(source, item, count)
+end
+
+---@param source number
+---@param item string
+---@param count number
+---@param metadata? table | string
+function stevo_lib.AddItem(source, item, count, metadata)
+    if not ox_inventory then return false end
+    return exports.ox_inventory:AddItem(source, item, count, metadata)
+end
+
+function stevo_lib.HasItem(source, item)
+    if not ox_inventory then return false end
+    local itemCount = exports.ox_inventory:GetItemCount(source, item)
+    return itemCount
+end
+
+function stevo_lib.GetInventory(source)
+    if not ox_inventory then return false end
+    local items = {}
+    local data = ox_inventory and exports.ox_inventory:GetInventoryItems(source)
+    for i = 1, #data do
+        local item = data[i]
+        items[#items + 1] = {
+            name = item.name,
+            label = item.label,
+            count = ox_inventory and item.count or item.amount,
+            weight = item.weight,
+            metadata = ox_inventory and item.metadata or item.info
+        }
+    end
+    return items
+end
+
+function stevo_lib.SetJob(source, jobName, jobGrade)
+    local player = Ox.GetPlayer(source)
+    local job = tostring(jobName)
+    local grade = tonumber(jobGrade)
+    player.setGroup(job, grade)
+    return player.setActiveGroup(job) -- * ox_core requires setting the active group separately
+end
+
+-- * Extra usable varibales for the cb in RegisterUsableItem
+function stevo_lib.RegisterUsableItem(_item, cb)
+    if not ox_inventory then return false end
+    exports(_item, function(event, item, inventory, slot, data)
+        cb(inventory.source, event, item, inventory, slot, data)
+    end)
+end

--- a/bridge/frameworks/ox_core/server.lua
+++ b/bridge/frameworks/ox_core/server.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable: duplicate-set-field
 local Ox = require '@ox_core.lib.init'
 local ox_inventory = GetResourceState('ox_inventory') == 'started' and true or false
 

--- a/bridge/frameworks/qb-core/client.lua
+++ b/bridge/frameworks/qb-core/client.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable: duplicate-set-field
 local QBCore = exports['qb-core']:GetCoreObject()
 local PlayerData
 

--- a/bridge/frameworks/qb-core/server.lua
+++ b/bridge/frameworks/qb-core/server.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable: duplicate-set-field
 local QBCore = exports['qb-core']:GetCoreObject()
 local ox_inventory = GetResourceState('ox_inventory') == 'started' and true or false
 
@@ -109,7 +110,7 @@ end
 function stevo_lib.SetJob(source, jobName, jobGrade)
     local player = QBCore.Functions.GetPlayer(source)
     local job = tostring(jobName)
-    local grade = tonumber(jobGrade) or 0 
+    local grade = tonumber(jobGrade) or 0
     return player.Functions.SetJob(job, grade)
 end
 

--- a/bridge/frameworks/qbx_core/client.lua
+++ b/bridge/frameworks/qbx_core/client.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable: duplicate-set-field
 local qbx_core = exports['qbx_core']
 
 local function GetConvertedClothes(oldClothes)

--- a/bridge/frameworks/qbx_core/server.lua
+++ b/bridge/frameworks/qbx_core/server.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable: duplicate-set-field
 local qbx_core = exports['qbx_core']
 local ox_inventory = exports['ox_inventory']
 

--- a/modules/init/client.lua
+++ b/modules/init/client.lua
@@ -40,10 +40,10 @@ end
 ld()
 
 -- Detect and load targeting system
-local qb_target = GetResourceState('qb-target')
-local ox_target = GetResourceState('ox_target')
-local interact = GetResourceState('interact')
-local target = ox_target == 'started' and 'ox_target' or qb_target == 'started' and 'qb-target' or interact == 'started' and 'interact' or nil 
+local qb_target = GetResourceState('qb-target') == 'started'
+local ox_target = GetResourceState('ox_target') == 'started'
+local interact = GetResourceState('interact') == 'started'
+local target = ox_target and 'ox_target' or qb_target and 'qb-target' or interact and 'interact' or nil
 
 if not target then 
     print('[Stevo Library] Unable to find target, defaulting to placeholder.')

--- a/modules/init/client.lua
+++ b/modules/init/client.lua
@@ -53,11 +53,11 @@ end
 stevo_lib.target = require(string.format('bridge.targets.%s', target))
 
 -- Detect and load keys system
-local qb_vehiclekeys = GetResourceState('qb-vehiclekeys')
-local qbx_vehiclekeys = GetResourceState('qbx_vehiclekeys')
-local renewed_vehiclekeys = GetResourceState('Renewed-VehicleKeys')
-local wasabi_carlock = GetResourceState('wasabi_carlock')
-local keys = qb_vehiclekeys == 'started' and 'qb-vehiclekeys' or qbx_vehiclekeys == 'started' and 'qbx_vehiclekeys' or renewed_vehiclekeys == 'started' and 'Renewed-VehicleKeys' or wasabi_carlock == 'started' and 'wasabi_carlock' or nil
+local qb_vehiclekeys = GetResourceState('qb-vehiclekeys') == 'started'
+local qbx_vehiclekeys = GetResourceState('qbx_vehiclekeys') == 'started'
+local renewed_vehiclekeys = GetResourceState('Renewed-VehicleKeys') == 'started'
+local wasabi_carlock = GetResourceState('wasabi_carlock') == 'started'
+local keys = qb_vehiclekeys and 'qb-vehiclekeys' or qbx_vehiclekeys and 'qbx_vehiclekeys' or renewed_vehiclekeys and 'Renewed-VehicleKeys' or wasabi_carlock and 'wasabi_carlock' or nil
 
 if not keys then 
     print('[Stevo Library] Unable to find your keys system, defaulting to placeholder.')

--- a/modules/init/client.lua
+++ b/modules/init/client.lua
@@ -7,16 +7,16 @@ exports("import", function()
 end)
 
 -- Framework and dependency detection
-local qb = GetResourceState('qb-core')
-local qbx = GetResourceState('qbx_core')
-local esx = GetResourceState('es_extended')
-local ox = GetResourceState('ox_core')
+local qb = GetResourceState('qb-core') == 'started'
+local qbx = GetResourceState('qbx_core') == 'started'
+local esx = GetResourceState('es_extended') == 'started'
+local ox = GetResourceState('ox_core') == 'started'
 
 if ox == 'started' then 
-    return error('[Stevo Library] ox_core is not supported by stevo_lib currently.')
+    lib.print.warn('ox_core support for stevo_lib is experimental. Use with care.')
 end
 
-local framework = qbx == 'started' and 'qbx_core' or qb == 'started' and 'qb-core' or esx == 'started' and 'es_extended' or nil 
+local framework = qbx and 'qbx_core' or qb and 'qb-core' or esx and 'es_extended' or ox and 'ox_core' or nil
 if not framework then 
     return error('[Stevo Library] Unable to find framework, This could be because you are using a modified framework name.') 
 end
@@ -61,7 +61,7 @@ local keys = qb_vehiclekeys == 'started' and 'qb-vehiclekeys' or qbx_vehiclekeys
 
 if not keys then 
     print('[Stevo Library] Unable to find your keys system, defaulting to placeholder.')
-    keys = 'placeholder' 
+    keys = 'placeholder'
 end
 
 stevo_lib.keys = require(string.format('bridge.keys.%s.client', keys))

--- a/modules/init/server.lua
+++ b/modules/init/server.lua
@@ -40,15 +40,15 @@ end
 ld()
 
 -- Detect and load keys system
-local qb_vehiclekeys = GetResourceState('qb-vehiclekeys')
-local qbx_vehiclekeys = GetResourceState('qbx_vehiclekeys')
-local renewed_vehiclekeys = GetResourceState('Renewed-VehicleKeys')
-local wasabi_carlock = GetResourceState('wasabi_carlock')
-local keys = qb_vehiclekeys == 'started' and 'qb-vehiclekeys' or qbx_vehiclekeys == 'started' and 'qbx_vehiclekeys' or renewed_vehiclekeys == 'started' and 'Renewed-VehicleKeys' or wasabi_carlock == 'started' and 'wasabi_carlock' or nil
+local qb_vehiclekeys = GetResourceState('qb-vehiclekeys') == 'started'
+local qbx_vehiclekeys = GetResourceState('qbx_vehiclekeys') == 'started'
+local renewed_vehiclekeys = GetResourceState('Renewed-VehicleKeys') == 'started'
+local wasabi_carlock = GetResourceState('wasabi_carlock') == 'started'
+local keys = qb_vehiclekeys and 'qb-vehiclekeys' or qbx_vehiclekeys and 'qbx_vehiclekeys' or renewed_vehiclekeys and 'Renewed-VehicleKeys' or wasabi_carlock and 'wasabi_carlock' or nil
 
 if not keys then 
     print('[Stevo Library] Unable to find your keys system, defaulting to placeholder.')
-    keys = 'placeholder' 
+    keys = 'placeholder'
 end
 
 stevo_lib.keys = require(string.format('bridge.keys.%s.server', keys))

--- a/modules/init/server.lua
+++ b/modules/init/server.lua
@@ -7,18 +7,18 @@ exports("import", function()
 end)
 
 -- Framework and dependency detection
-local qb = GetResourceState('qb-core')
-local qbx = GetResourceState('qbx_core')
-local esx = GetResourceState('es_extended')
-local ox = GetResourceState('ox_core')
+local qb = GetResourceState('qb-core') == 'started'
+local qbx = GetResourceState('qbx_core') == 'started'
+local esx = GetResourceState('es_extended') == 'started'
+local ox = GetResourceState('ox_core') == 'started'
 
 if ox == 'started' then 
-    return error('[Stevo Library] ox_core is not supported by stevo_lib currently.')
+    lib.print.warn('ox_core support for stevo_lib is experimental. Use with care.')
 end
 
-local framework = qbx == 'started' and 'qbx_core' or qb == 'started' and 'qb-core' or esx == 'started' and 'es_extended' or nil 
+local framework = qbx and 'qbx_core' or qb and 'qb-core' or esx and 'es_extended' or ox and 'ox_core' or nil
 if not framework then 
-    return error('[Stevo Library] Unable to find framework, This could be because you are using a modified framework name.') 
+    return error('[Stevo Library] Unable to find framework, This could be because you are using a modified framework name.')
 end
 
 stevo_lib.framework = framework


### PR DESCRIPTION
## Framework Support
I wasn't able to get a few functions to use solely ox_core like inventory (as it doesn't have one built in - deferred to ox_inventory) + gang functions. Framework implementations are untested, thought I'd PR though. This won't cause any errors for users of other frameworks however official support for ox_core should not be advertised yet.

## Code Cleanup
The modules/init/client.lua & modules/init/server.lua have been changed to remedy the outlandishly long `keys` and `target` variables.

## Intellisense
LLS likes to complain alot about the duplicate functions (this problem is non-existent)